### PR TITLE
Mutex spending

### DIFF
--- a/src/CppBridge.js
+++ b/src/CppBridge.js
@@ -1,8 +1,9 @@
 // This has been taken from @mymonero/mymonero-monero-client v2.0.0
-// All methods have been marked `async`,
-// we have removed a try-catch block,
-// the send_amount check for sweeping transactions has been changed from number 0 to string '0'
-// and the class has been renamed from `WABridge` to `CppBridge`.
+// Changes include:
+// - Rename the class from `WABridge` to `CppBridge`
+// - Make all methods `async`
+// - Remove a try-catch block
+// - Change the shouldSweep `send_amount` check from number 0 to string '0'
 
 'use strict'
 

--- a/src/CppBridge.js
+++ b/src/CppBridge.js
@@ -5,14 +5,28 @@
 // - Remove a try-catch block
 // - Change the shouldSweep `send_amount` check from number 0 to string '0'
 // - Add a mutex around `createTransaction`
+// - Assemble the `this.Module` property in the constructor
 
 'use strict'
 
 let lastSpend = Promise.resolve()
 
 class CppBridge {
-  constructor (module) {
-    this.Module = module
+  constructor (MyMoneroCore) {
+    // Put the methods back together:
+    this.Module = {}
+    for (const name of MyMoneroCore.methodNames) {
+      this.Module[name] = function (...args) {
+        return MyMoneroCore.callMyMonero(name, args).then(out => {
+          // We have to cast some return values:
+          return name === 'compareMnemonics' ||
+            name === 'isIntegratedAddress' ||
+            name === 'isSubaddress'
+            ? Boolean(out)
+            : out
+        })
+      }
+    }
 
     // Only allow one createTransaction call at a time:
     const oldCreateTransaction = this.createTransaction.bind(this)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,9 @@
  * The shape of the native C++ module exposed to React Native.
  *
  * You do not normally need this, but it is accessible as
- * `require('react-native').NativeModules.MyMoneroCore`
+ * `require('react-native').NativeModules.MyMoneroCore`.
+ *
+ * Pass this object to the `CppBridge` constructor to re-assemble the API.
  */
 export interface NativeMyMoneroCore {
   readonly callMyMonero: (

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,4 @@
 const { NativeModules } = require('react-native')
 const CppBridge = require('./CppBridge.js')
 
-const { MyMoneroCore } = NativeModules
-
-// Put the methods back together:
-const methods = {}
-for (const name of MyMoneroCore.methodNames) {
-  methods[name] = function (...args) {
-    return MyMoneroCore.callMyMonero(name, args).then(out => {
-      // We have to cast some return values:
-      return name === 'compareMnemonics' ||
-        name === 'isIntegratedAddress' ||
-        name === 'isSubaddress'
-        ? Boolean(out)
-        : out
-    })
-  }
-}
-
-module.exports = new CppBridge(methods)
+module.exports = new CppBridge(NativeModules.MyMoneroCore)


### PR DESCRIPTION
- changed: Do not allow multiple parallel calls to `createTransaction`. Instead, wait for the previous call to complete before starting the next one.
- changed: Simplify and document the relationship between the React Native bridge and the CppBridge object.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204472481313042